### PR TITLE
add 6to5 link

### DIFF
--- a/1_ecosystem.md
+++ b/1_ecosystem.md
@@ -5,6 +5,9 @@
 ### JavaScript modules
 :book: http://jsmodules.io/
 
+### ES6 syntax
+:book: https://6to5.org/docs/learn-es6/
+
 You'll use this syntax in your Ember apps. Read this short page.
 
 ### Ember CLI documentation


### PR DESCRIPTION
Since ember-cli now ships with [6to5](https://6to5.org/docs/learn-es6/) this should be a part of the docs.
